### PR TITLE
Fixes issues with custom_dump when one or more dependencies return QuerySet objects.

### DIFF
--- a/fixture_magic/utils.py
+++ b/fixture_magic/utils.py
@@ -51,6 +51,9 @@ def add_to_serialize_list(objs):
     for obj in objs:
         if obj is None:
             continue
+        if not hasattr(obj, '_meta'):
+            add_to_serialize_list(obj)
+            continue
 
         # Proxy models don't serialize well in Django.
         if obj._meta.proxy:


### PR DESCRIPTION
This happens because line 36 of custom_dump.py wraps the queryset in a list, making objs a list with a single element (the QuerySet object), which then makes the QuerySet object equal to obj on the only iteration of the for-loop, which raises an AttributeError due to QuerySet objects having no attribute '_meta'.
