### PR TITLE
added an option for dump_object to accept a id list file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
         name='django-fixture-magic',
-        version='0.0.3',
+        version='0.0.4',
         description='A few extra management tools to handle fixtures.',
         long_description=open('README.rst').read(),
         author='Dave Dash',


### PR DESCRIPTION
I have a long list of ids I want to dump, so I made this minor change to support loading a list of ids from a file. Hopefully it will be useful for others.
