### PR TITLE
Allow dump_object to be used with primary keys that are longs

### DIFF
--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -41,8 +41,12 @@ class Command(BaseCommand):
         try:
             objs = dump_me.objects.filter(pk__in=[int(i) for i in ids])
         except ValueError:
-            # We might have primary keys thar are just strings...
-            objs = dump_me.objects.filter(pk__in=ids)
+            # We might have primary keys that are longs...
+            try:
+                objs = dump_me.objects.filter(pk__in=[long(i) for i in ids]) 
+            except ValueError:
+                # Finally, we might have primary keys that are strings...
+                objs = dump_me.objects.filter(pk__in=ids)
 
         if options.get('kitchensink'):
             related_fields = [rel.get_accessor_name() for rel in


### PR DESCRIPTION
I needed to use the dump_object command to generate fixtures for a model with primary keys that are longs (i.e. not ints or strings).  For example dump_object myModel 437L.  With the existing code, that would be converted to the string "437L", and that breaks when the query is executed.  

I acknowledge that this solution won't work for string primary keys that look like python long literals (e.g. if you have a primary key that is a string equal to something like "437L"), but I feel like that would be an extremely rare case and that the use of longs in general as primary keys is a common enough scenario such that it warrants this change.

Let me know what you think.
