### PR TITLE
Update argument to serialize all objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ a specific object as well as all its dependencies (as defined by ForeignKeys).
 
 Or you can get all objects with all dependencies:
 
-    ./manage.py dump_object APP.MODEL * > my_new_fixture.json
+    ./manage.py dump_object APP.MODEL all > my_new_fixture.json
 
 You can now safely load ``my_new_fixture.json`` in a test without foreign key i
 errors.

--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
         dump_me = loading.get_model(app_label, model_name)
         try:
-            if ids[0] == '*':
+            if ids[0] == 'all':
                 objs = dump_me.objects.all()
             else:
                 objs = dump_me.objects.filter(pk__in=[int(i) for i in ids])


### PR DESCRIPTION
The `*` argument to select all objects created in [Issue 10](https://github.com/davedash/django-fixture-magic/pull/10) does not quite work correctly. In the console, `*` is an alias to select all the files in the current directory. To actually select all objects---and not provide the `dump_object` command with a list of files---you had to use `'*'` or  `"*"`. I changed the parameter to `all`, which seemed more intuitive than `"*"`
