### PR TITLE
Deterministic json from merging fixtures.

### DIFF
--- a/fixture_magic/management/commands/merge_fixtures.py
+++ b/fixture_magic/management/commands/merge_fixtures.py
@@ -5,6 +5,15 @@ except ImportError:
 
 from django.core.management.base import BaseCommand
 
+def write_json(output):
+    try:
+        # check our json import supports sorting keys
+        json.dumps([1], sort_keys=True)
+    except TypeError:
+        print json.dumps(output, indent=4)
+    else:
+        print json.dumps(output, sort_keys=True, indent=4)
+
 class Command(BaseCommand):
     help = ('Merge a series of fixtures and remove duplicates.')
     args = '[file ...]'
@@ -26,4 +35,4 @@ class Command(BaseCommand):
                     seen[key] = 1
                     output.append(object)
 
-        print json.dumps(output, indent=4)
+        write_json(output)


### PR DESCRIPTION
Being able to run diffs on your fixtures is very useful, especially if when they are going into a VCS.

simplejson doesn't seem to support the sort_keys kwarg, so I fall back to unsorted if required.
