### PR TITLE
Replaced "print" with "self.stdout.write" 

### DIFF
--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -62,5 +62,5 @@ class Command(BaseCommand):
 
         add_to_serialize_list(objs)
         serialize_fully()
-        print serialize('json', [o for o in serialize_me if o is not None],
-                        indent=4)
+        self.stdout.write(serialize('json', [o for o in serialize_me if o is not None],
+                indent=4))


### PR DESCRIPTION
This way, the output can be redirected via call_command:
https://docs.djangoproject.com/en/dev/ref/django-admin/#running-management-commands-from-your-code
