### PR TITLE
Handle one to one relationships

### DIFF
--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -58,7 +58,10 @@ class Command(BaseCommand):
             for obj in objs:
                 for rel in related_fields:
                     try:
-                        add_to_serialize_list(obj.__getattribute__(rel).all())
+                        if hasattr(getattr(obj, rel), 'all'):
+                            add_to_serialize_list(getattr(obj, rel).all())
+                        else:
+                            add_to_serialize_list([getattr(obj, rel)])
                     except FieldError:
                         pass
                     except ObjectDoesNotExist:


### PR DESCRIPTION
One-to-one relationships do not have the attribute 'all'.
For a one-to-one relationship, `getattr(obj, rel)` returns the object itself. 