### PR TITLE
Updates to custom dump

### DIFF
--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import sys
+from optparse import make_option
+
 try:
     import json
 except ImportError:
@@ -22,10 +24,18 @@ class Command(BaseCommand):
     help = 'Dump multiple pre-defined sets of objects into a JSON fixture.'
     args = "[dump_name pk [pk2 pk3 [..]]"
 
+    option_list = BaseCommand.option_list + (
+        make_option('--natural', '-n',
+                    action='store_true', dest='natural',
+                    default=False,
+                    help='Use natural keys if they are available.'),
+    )
+
     def handle(self, dump_name, *pks, **options):
         # Get the primary object
         dump_settings = settings.CUSTOM_DUMPS[dump_name]
         (app_label, model_name) = dump_settings['primary'].split('.')
+        include_primary = dump_settings.get("include_primary", False)
         dump_me = loading.get_model(app_label, model_name)
         objs = dump_me.objects.filter(pk__in=[int(i) for i in pks])
         for obj in objs:
@@ -37,11 +47,15 @@ class Command(BaseCommand):
                 except VariableDoesNotExist:
                     sys.stderr.write('%s not found' % dep)
 
-            if not dump_settings['dependents']:
+            if include_primary or not dump_settings['dependents']:
                 add_to_serialize_list([obj])
 
         serialize_fully()
-        data = serialize('json', [o for o in serialize_me if o is not None])
+        data = serialize('json', [o for o in serialize_me if o is not None],
+                         indent=4,
+                         use_natural_foreign_keys=options.get('natural', False),
+                         use_natural_primary_keys=options.get('natural', False),
+                         )
 
         data = reorder_json(json.loads(data), dump_settings.get('order', []),
                 ordering_cond=dump_settings.get('order_cond',{}))


### PR DESCRIPTION
I added the ability to use natural keys in the custom dump which exists for the dump_object command, but not this one.
I also included an option to include the primary object in the dump. I actually can not see why the default is to remove this object, but for backward compatibility, I added an option to include it, which defaults to False