### PR TITLE
Support running dump_object multiple times in single execution

### DIFF
--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -11,8 +11,8 @@ except ImportError:
     from django.apps import apps as loading
 import json
 
-from fixture_magic.utils import (add_to_serialize_list, serialize_me,
-        serialize_fully)
+from fixture_magic.utils import (add_to_serialize_list, serialize_me, seen,
+                                 serialize_fully)
 
 
 class Command(BaseCommand):
@@ -96,3 +96,4 @@ class Command(BaseCommand):
 
         # Clear the list. Useful for when calling multiple dump_object commands with a single execution of django
         del serialize_me[:]
+        seen.clear()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pytest==2.3.5
 pytest-cov==1.6
-Django==1.5.4
+Django>=1.9


### PR DESCRIPTION
In my workflow, I run dump_object many times in a single execution... The gotcha I hit was the seen dict was never getting cleared, meaning that subsequent calls would be missing things that should be exported. This fix addresses that.