### PR TITLE
Update custom_dump.py for django>=1.10

### DIFF
--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
     help = 'Dump multiple pre-defined sets of objects into a JSON fixture.'
     args = "[dump_name pk [pk2 pk3 [..]]"
 
-    option_list = BaseCommand.option_list + (
+    option_list = getattr(BaseCommand, 'option_list', ()) + (
         make_option('--natural', '-n',
                     action='store_true', dest='natural',
                     default=False,


### PR DESCRIPTION
In Django 1.10 BaseCommand no longer has an `option_list` attribute. This PR follows suit with the solution provided by other major modules.