### PR TITLE
removing args from Command class - not used since Django 1.7

### DIFF
--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -19,8 +19,6 @@ from fixture_magic.utils import (add_to_serialize_list, serialize_me, seen,
 class Command(BaseCommand):
     help = ('Dump specific objects from the database into JSON that you can '
             'use in a fixture.')
-    args = "<[--kitchensink | -k] [--natural] [--query] object_class id [id ...]>"
-
 
     def add_arguments(self, parser):
         """Add command line arguments to parser"""


### PR DESCRIPTION
Django 1.7 is no longer supported and this is no longer in the Django docs. Recommend removing as add_arguments is doing all of this for you.