### PR TITLE
Remove deprecated `--use-wheel` flag and update Django supported vers…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-.. image:: https://travis-ci.org/davedash/django-fixture-magic.png
+.. image:: https://travis-ci.org/davedash/django-fixture-magic.png?branch=master
+    :target: https://travis-ci.org/davedash/django-fixture-magic
 
 
 
@@ -8,7 +9,7 @@ Requirements
 
 This package requires:
 
-* Python 2.6
+* Python 2.7
 * Django
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,14 @@
 [tox]
 envlist =
-    py27-django17,
     py27-django18,
     py27-django19,
-    py27-django110
+    py27-django110,
+    py27-django111
 
 [testenv]
 commands =
-    pip install -r requirements.txt --use-wheel
+    pip install -r requirements.txt
     py.test --junitxml=junit-{envname}.xml --cov-report xml --cov fixture_magic
-
-[testenv:py27-django17]
-basepython = python2.7
-deps = Django>=1.7,<1.7.99
 
 [testenv:py27-django18]
 basepython = python2.7
@@ -25,3 +21,7 @@ deps = Django>=1.9,<1.9.99
 [testenv:py27-django110]
 basepython = python2.7
 deps = Django>=1.10,<1.10.99
+
+[testenv:py27-django111]
+basepython = python2.7
+deps = Django>=1.11,<1.11.99


### PR DESCRIPTION
…ions for Python 2.7.

Hi Dave,

First off, thank you for `django-fixture-magic`. It saved me a lot of time on a project I was working on this week, and it worked like a charm!

I noticed that Travis CI tests were failing due to a `pip` error with the `--use-wheel` flag. It looks like it was deprecated in the [7.0.0 release](https://pip.pypa.io/en/stable/news/#id25), and if I am reading the notes correctly, that it's enabled by default now.

I also updated Python 2.7 test coverage to align with [Django's supported versions of Python](https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django). **Btw - If you are interested in adding Python 3.x Travis CI coverage, let me know and I'd be happy to give reconfiguration a shot. I'm using this package currently with Python 3.**

One favor to ask. If all looks okay, can you deploy `0.1.4`? It looks like it's sitting in the queue, but hasn't been deployed to PyPI. I believe this will clear up the issues that some people have seen (myself included) trying to run `merge_fixtures`, `reorder_fixtures`, etc. PyPI deploys have changed slightly, but this thread has new deploy steps - https://stackoverflow.com/questions/45207128/failed-to-upload-packages-to-pypi-410-gone.

This is a great package and thanks again!

Sean