### PR TITLE
Allow natural keys (#1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest==2.3.5
 pytest-cov==1.6
 future==0.15.2
+six==1.14.0


### PR DESCRIPTION
I've noticed that using `dump_object --natural` and then trying to merge multpile fixtures using `merge_fixtures` does not work - `merge_fixtures` is expecting `pk` to be present. 
This PR "fixes" that. If `pk` is not present (as in i.e. `contenttype` or `permission`) it uses all of the string values as a key.