### PR TITLE
Update tests for Django 4.2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = fixture_magic
+
+[report]
+omit =
+    tests

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist = py{37,38,39,310}-django{32}
           py{39,310}-django{40}
-          py{39,310}-django{41}
+          py{39,310,311}-django{41}
+          py{39,310,311}-django{42}
 
 [travis]
 python =
@@ -9,6 +10,8 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
+  3.12: py312
 
 [testenv]
 setenv =
@@ -16,13 +19,15 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/django-fixture-magic:{toxinidir}/tests
 
 commands =
-    coverage run --source='.' {envbindir}/django-admin test
+    coverage run -m django test --settings=tests.settings
+    coverage report
 
 allowlist_externals =
-    django-admin
+    coverage
 
 deps =
     coverage
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0


### PR DESCRIPTION
Follow up of https://github.com/davedash/django-fixture-magic/pull/85

* Adds Django 4.2 to test runner
* Adds Python 3.11 and 3.12 to test runner
* Updates how we run coverage to be a little more stable across python versions
* Adds a .coveragerc file to configure coverage to ignore test files in reporting