### PR TITLE
Add exclude model option to dump_object

### DIFF
--- a/fixture_magic/compat.py
+++ b/fixture_magic/compat.py
@@ -1,8 +1,9 @@
 
 
-def get_all_related_objects(model, exclude_fields):
+def get_all_related_objects(model, exclude_fields, exclude_models):
     return [
         f for f in model._meta.get_fields() if
         (f.one_to_many or f.one_to_one) and
         f.auto_created and not f.concrete and f.name not in exclude_fields
+        and f.related_model not in exclude_models
     ]

--- a/fixture_magic/management/commands/dump_object.py
+++ b/fixture_magic/management/commands/dump_object.py
@@ -39,6 +39,10 @@ class Command(BaseCommand):
                             default=[],
                             nargs='*',
                             help='List of excluded fields (works for all models)')
+        parser.add_argument('--exclude-models', '-m',
+                            default=[],
+                            nargs='*',
+                            help='List of excluded models. Eg: app_name.model_name1 app_name.model_name2')
         parser.add_argument('--natural', '-n',
                             action='store_true', dest='natural',
                             default=False,
@@ -91,6 +95,15 @@ class Command(BaseCommand):
         except AssertionError:
             raise CommandError(error_text % 'No filter argument supplied.')
 
+        exclude_models = []
+        for exclude_model in options['exclude_models']:
+            try:
+                (exclude_app_label, exclude_model_name) = exclude_model.split('.')
+            except AttributeError:
+                raise CommandError("Specify exclude-model as `appname.modelname`")
+
+            exclude_models.append(loading.get_model(exclude_app_label, exclude_model_name))
+
         dump_me = loading.get_model(app_label, model_name)
         if query:
             objs = dump_me.objects.filter(**json.loads(query))
@@ -113,7 +126,7 @@ class Command(BaseCommand):
                     objs = []
 
         if options.get('kitchensink'):
-            fields = get_all_related_objects(dump_me, options['exclude_fields'])
+            fields = get_all_related_objects(dump_me, options['exclude_fields'], exclude_models)
 
             related_fields = [rel.get_accessor_name() for rel in fields]
 
@@ -132,7 +145,7 @@ class Command(BaseCommand):
         add_to_serialize_list(objs)
 
         if options.get('follow_fk', True):
-            serialize_fully(options['exclude_fields'])
+            serialize_fully(options['exclude_fields'], exclude_models)
         else:
             # reverse list to match output of serializez_fully
             serialize_me.reverse()

--- a/fixture_magic/utils.py
+++ b/fixture_magic/utils.py
@@ -52,18 +52,20 @@ def get_m2m(obj, *exclude_fields):
         return []
 
 
-def serialize_fully(exclude_fields):
+def serialize_fully(exclude_fields, exclude_models):
     index = 0
     exclude_fields = exclude_fields or ()
+    exclude_models = exclude_models or ()
 
     while index < len(serialize_me):
         for field in get_fields(serialize_me[index], *exclude_fields):
-            if isinstance(field, models.ForeignKey):
+            if isinstance(field, models.ForeignKey) and field.related_model not in exclude_models:
                 add_to_serialize_list(
                     [serialize_me[index].__getattribute__(field.name)])
         for field in get_m2m(serialize_me[index], *exclude_fields):
-            add_to_serialize_list(
-                serialize_me[index].__getattribute__(field.name).all())
+            if field.related_model not in exclude_models:
+                add_to_serialize_list(
+                    serialize_me[index].__getattribute__(field.name).all())
 
         index += 1
 

--- a/tests/fixture_magic/test_utils.py
+++ b/tests/fixture_magic/test_utils.py
@@ -1,8 +1,9 @@
 import unittest
 
+from fixture_magic.compat import get_all_related_objects
 from fixture_magic.utils import reorder_json, get_fields, get_m2m
 
-from .models import Person, Group
+from .models import Person, Group, Membership
 
 __author__ = 'davedash'
 
@@ -30,3 +31,9 @@ class UtilsTestCase(unittest.TestCase):
         fields = get_m2m(Group)
         field_names = [field.name for field in fields]
         self.assertIn("members", field_names)
+
+    def test_exclude_models(self):
+        related_objs = get_all_related_objects(Group, [], [])
+        self.assertEqual(len(related_objs), 1, "Confirm no models were excluded.")
+        related_objs = get_all_related_objects(Group, [], [Membership])
+        self.assertEqual(len(related_objs), 0, "Confirmed exclude model not in included.")


### PR DESCRIPTION
Adding a `--exclude-models` similar to exclude-fields. This allows on our use case to exclude some models that we know it should not be included in the dump_object fixture.

There wasn't a contribute guide, but I tried following the code base flow and included a test.

Example Usage:

```
./manage.py dump_object app_name.model_name 1 --kitchensink --exclude-models app_name.model_name1 app_name.model2
```